### PR TITLE
improvement: Tweak module outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,10 @@ using submodules, placed in `./modules` directory
 | <a name="output_arn"></a> [arn](#output\_arn) | ARN of the organization |
 | <a name="output_id"></a> [id](#output\_id) | Identifier of the organization |
 | <a name="output_master_account_arn"></a> [master\_account\_arn](#output\_master\_account\_arn) | ARN of the master account |
+| <a name="output_non_master_accounts"></a> [non\_master\_accounts](#output\_non\_master\_accounts) | List of organization accounts including the master account |
 | <a name="output_organizational_units"></a> [organizational\_units](#output\_organizational\_units) | Details of Organizational Units |
 | <a name="output_policies"></a> [policies](#output\_policies) | Details of Policies |
+| <a name="output_root_accounts"></a> [root\_accounts](#output\_root\_accounts) | Details of AWS Accounts created under organizations root |
 | <a name="output_roots"></a> [roots](#output\_roots) | List of organization roots |
 
 ## Providers

--- a/modules/account/README.md
+++ b/modules/account/README.md
@@ -50,6 +50,7 @@ It also provides functionality to attach a list of organizational policies to th
 | <a name="output_email"></a> [email](#output\_email) | e-mail associated with this AWS account |
 | <a name="output_id"></a> [id](#output\_id) | ID of this AWS account |
 | <a name="output_name"></a> [name](#output\_name) | Name of this AWS account |
+| <a name="output_role_arn"></a> [role\_arn](#output\_role\_arn) | The name of an IAM role that Organizations automatically preconfigures in the new member account. This role trusts the root account, allowing users in the root account to assume the role, as permitted by the root account administrator. The role has administrator permissions in the new member account. |
 
 ## Providers
 

--- a/modules/account/locals.tf
+++ b/modules/account/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  account_name = can(module.this.descriptors["organizations_account"]) ? module.this.descriptors["organizations_account"] : module.this.id
+
+  role_name = resource.aws_organizations_account.this_organizations_account.role_name != null ? resource.aws_organizations_account.this_organizations_account.role_name : "OrganizationAccountAccessRole"
+  role_arn  = "arn:aws:iam::${resource.aws_organizations_account.this_organizations_account.id}:role/${local.role_name}"
+}

--- a/modules/account/main.tf
+++ b/modules/account/main.tf
@@ -7,7 +7,7 @@
  */
 
 resource "aws_organizations_account" "this_organizations_account" {
-  name      = can(module.this.descriptors["organizations_account"]) ? module.this.descriptors["organizations_account"] : module.this.id
+  name      = local.account_name
   email     = var.email
   parent_id = var.parent_id
   role_name = var.role_name == "" ? null : var.role_name

--- a/modules/account/outputs.tf
+++ b/modules/account/outputs.tf
@@ -17,3 +17,8 @@ output "email" {
   description = "e-mail associated with this AWS account"
   value       = resource.aws_organizations_account.this_organizations_account.email
 }
+
+output "role_arn" {
+  description = "The name of an IAM role that Organizations automatically preconfigures in the new member account. This role trusts the root account, allowing users in the root account to assume the role, as permitted by the root account administrator. The role has administrator permissions in the new member account."
+  value       = local.role_arn
+}

--- a/modules/organizational-unit/README.md
+++ b/modules/organizational-unit/README.md
@@ -46,7 +46,7 @@ It also provides functionality to attach a list of organizational policies to th
 
 | Name | Description |
 |------|-------------|
-| <a name="output_accounts"></a> [accounts](#output\_accounts) | List of OU child accounts |
+| <a name="output_accounts"></a> [accounts](#output\_accounts) | Map of OU child accounts |
 | <a name="output_arn"></a> [arn](#output\_arn) | ARN of this OU |
 | <a name="output_id"></a> [id](#output\_id) | ID of this OU |
 

--- a/modules/organizational-unit/outputs.tf
+++ b/modules/organizational-unit/outputs.tf
@@ -9,6 +9,6 @@ output "id" {
 }
 
 output "accounts" {
-  description = "List of OU child accounts"
-  value       = resource.aws_organizations_organizational_unit.this_orgranizations_organizational_unit.accounts
+  description = "Map of OU child accounts"
+  value       = module.this_orgranizations_organizational_unit_account
 }

--- a/modules/organizational-unit/variables.tf
+++ b/modules/organizational-unit/variables.tf
@@ -4,7 +4,7 @@ variable "parent_id" {
 }
 
 variable "accounts" {
-  description = "List of AWS accounts to be created inside of that OU"
+  description = "Map of AWS accounts to be created inside of that OU"
   type        = any
   default     = {}
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,11 @@ output "accounts" {
   value       = resource.aws_organizations_organization.this_organizations_organization.accounts
 }
 
+output "non_master_accounts" {
+  description = "List of organization accounts including the master account"
+  value       = resource.aws_organizations_organization.this_organizations_organization.non_master_accounts
+}
+
 output "master_account_arn" {
   description = "ARN of the master account"
   value       = resource.aws_organizations_organization.this_organizations_organization.master_account_arn
@@ -31,4 +36,9 @@ output "organizational_units" {
 output "policies" {
   description = "Details of Policies"
   value       = module.this_policies
+}
+
+output "root_accounts" {
+  description = "Details of AWS Accounts created under organizations root"
+  value       = module.this_root_accounts
 }


### PR DESCRIPTION
Tweak module and submodule outputs:
* Return map instead of list of maps where not needed
* Add additional, useful outputs from the module and submodules (like account access role ARN)
* Small refactor of `account` module - move logic to `locals.tf`